### PR TITLE
Fix greedy regex breaking markup when UUID tags are present

### DIFF
--- a/scripts/HTMLParser.ts
+++ b/scripts/HTMLParser.ts
@@ -48,7 +48,7 @@ class HTMLParser {
   }
 
   private static _regexReplace(journalHtml: string) {
-    const regUUID = /@UUID\[(.+)\]\{(.+)\}/g;
+    const regUUID = /@UUID\[(.*?)\]\{(.*?)\}/g;
     const regUrl = /img src="((?!http:\/\/)(?!https:\/\/))/g;
     const regCssUrl = /(src|background): url\("\.\./g;
     const fontAwesome = /(\/webfonts\/)/g;


### PR DESCRIPTION
# Description

Fix greedy regex breaking markup when UUID tags are present

Fixes #61
Fixes #41

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)